### PR TITLE
[UIMA-6023] fix String.replaceAll() to replace() to improve performance

### DIFF
--- a/uima-ducc-user/src/main/java/org/apache/uima/ducc/user/common/UimaUtils.java
+++ b/uima-ducc-user/src/main/java/org/apache/uima/ducc/user/common/UimaUtils.java
@@ -236,10 +236,10 @@ public class UimaUtils {
 			// "\" with ".". We will use the ae
 			// descriptor name as AE key in the aggregate
 			if (key.indexOf("/") != -1) {
-				key = key.replaceAll("/", ".");
+				key = key.replace("/", ".");
 			}
 			if (key.indexOf("\\") != -1) {
-				key = key.replaceAll("\\\\", ".");
+				key = key.replace("\\", ".");
 			}
 			key = key.substring(key.lastIndexOf(".") + 1);
 			desc.getDelegateAnalysisEngineSpecifiersWithImports().put(key,


### PR DESCRIPTION
Fix ISSUE [#UIMA-6023](https://issues.apache.org/jira/browse/UIMA-6023).
When there is no need to use regular expression to perform string replacing, the other method String.replace() should be preferred as it is more efficient without pre-compiling the regex ahead of time.